### PR TITLE
Remove :memory strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ It wraps the `libsqlite3` library.
 ## Example
 
 ```rs
-// Create an in-memory database connection with the name :memory
+// Create an in-memory database connection with the name db1
 let mut conn = asqlite::Connection::builder()
     .create(true) // create if it does not exists
     .write(true) // read and write
-    .open_memory(":memory") // to open a file, use .open(path)
+    .open_memory("db1") // to open a file, use .open(path)
     .await?;
 
 // Create a table

--- a/examples/apple.rs
+++ b/examples/apple.rs
@@ -3,11 +3,11 @@ use std::io;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    // Create an in-memory database connection with the name :memory
+    // Create an in-memory database connection with the name db1
     let mut conn = asqlite::Connection::builder()
         .create(true) // create if it does not exists
         .write(true) // read and write
-        .open_memory(":memory") // to open a file, use .open(path)
+        .open_memory("db1") // to open a file, use .open(path)
         .await?;
 
     // Create a table

--- a/examples/apples_and_oranges.rs
+++ b/examples/apples_and_oranges.rs
@@ -3,11 +3,11 @@ use std::io;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    // Create an in-memory database connection with the name :memory
+    // Create an in-memory database connection with the name db1
     let mut conn = asqlite::Connection::builder()
         .create(true) // create if it does not exists
         .write(true) // read and write
-        .open_memory(":memory") // to open a file, use .open(path)
+        .open_memory("db1") // to open a file, use .open(path)
         .await?;
 
     // Create a table

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -25,7 +25,7 @@ mod write;
 /// # let mut conn = asqlite::Connection::builder()
 /// #    .write(true)
 /// #    .create(true)
-/// #    .open_memory(":memory")
+/// #    .open_memory("db1")
 /// #    .await?;
 /// # conn.execute("CREATE TABLE my_table (column BLOB);", ()).await?;
 /// use futures::AsyncWriteExt;

--- a/src/connection/builder.rs
+++ b/src/connection/builder.rs
@@ -21,7 +21,7 @@ impl ConnectionBuilder {
     /// let conn = asqlite::ConnectionBuilder::new()
     ///     .write(true)
     ///     .create(true)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -48,7 +48,7 @@ impl ConnectionBuilder {
     /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// let conn = asqlite::ConnectionBuilder::new()
     ///     .write(true)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -72,7 +72,7 @@ impl ConnectionBuilder {
     /// let conn = asqlite::ConnectionBuilder::new()
     ///     .write(true)
     ///     .create(true)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -94,7 +94,7 @@ impl ConnectionBuilder {
     /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// let conn = asqlite::ConnectionBuilder::new()
     ///     .shared_cache(true)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -115,7 +115,7 @@ impl ConnectionBuilder {
     /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// let conn = asqlite::ConnectionBuilder::new()
     ///     .statement_cache_capacity(1024)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -192,7 +192,7 @@ impl ConnectionBuilder {
     /// ```
     /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
     /// let conn = asqlite::ConnectionBuilder::new()
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -33,7 +33,7 @@ pub use self::builder::*;
 /// let mut conn = asqlite::Connection::builder()
 ///     .write(true)
 ///     .create(true)
-///     .open_memory(":memory")
+///     .open_memory("db1")
 ///     .await?;
 /// conn.execute("CREATE TABLE person (name TEXT, age INTEGER)", ())
 ///     .await?;
@@ -84,7 +84,7 @@ impl Connection {
     /// let conn = asqlite::Connection::builder()
     ///     .write(true)
     ///     .create(true)
-    ///     .open_memory(":memory")
+    ///     .open_memory("db1")
     ///     .await?;
     /// # asqlite::Result::<()>::Ok(())
     /// # }).unwrap();
@@ -124,7 +124,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE user (user_id INT, secret TEXT)", ()).await?;
     /// # conn.execute("INSERT INTO user (user_id, secret) VALUES (1, ':)')", ()).await?;
@@ -185,7 +185,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE table_1 (id INT)", ()).await?;
     /// # conn.execute("CREATE TABLE table_2 (id INT)", ()).await?;
@@ -218,7 +218,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// conn.execute("CREATE TABLE user (user_id INT, secret TEXT)", ()).await?;
     /// # asqlite::Result::<()>::Ok(())
@@ -244,7 +244,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// conn.execute_batch(
     ///     r#"CREATE TABLE user (user_id INT, secret TEXT);
@@ -276,7 +276,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE table_1 (id INT)", ()).await?;
     /// let row = conn.insert(
@@ -307,7 +307,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE user (user_id INT, secret TEXT)", ()).await?;
     /// # conn.execute("INSERT INTO user (user_id, secret) VALUES (1, ':)')", ()).await?;
@@ -345,7 +345,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE user (user_id INT, secret TEXT)", ()).await?;
     /// # conn.execute("INSERT INTO user (user_id, secret) VALUES (1, ':)')", ()).await?;
@@ -433,7 +433,7 @@ impl Connection {
     /// # let mut conn = asqlite::Connection::builder()
     /// #    .write(true)
     /// #    .create(true)
-    /// #    .open_memory(":memory")
+    /// #    .open_memory("db1")
     /// #    .await?;
     /// # conn.execute("CREATE TABLE my_table (column BLOB);", ()).await?;
     /// let id = conn.insert("INSERT INTO my_table (column) VALUES (?);",


### PR DESCRIPTION
This is confusing, since the correct URL for memory databases is :memory: instead of :memory.

Anyways, due to the way building the connection works, using this specific string isn't necessary either.